### PR TITLE
[CARE-47] setting swagger for get all api from micro server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	// Spring cloud Gateway
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.4'
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// JWT

--- a/src/main/java/com/caring/apigateway_service/filter/ManagerAuthorizationHeaderFilter.java
+++ b/src/main/java/com/caring/apigateway_service/filter/ManagerAuthorizationHeaderFilter.java
@@ -38,7 +38,7 @@ public class ManagerAuthorizationHeaderFilter extends AbstractGatewayFilterFacto
             MemberInfo memberInfo = TokenUtil.parseJwt(jwt, env.getProperty("token.secret-manager"));
 
             if (memberInfo.getMemberCode() == null) {
-                return onError(exchange, "Invalid MANGER JWT token", HttpStatus.UNAUTHORIZED);
+                return onError(exchange, "Invalid MANAGER JWT token", HttpStatus.UNAUTHORIZED);
             }
 
             // 새로운 요청에 memberCode를 추가

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       routes:
         ### USER ###
         ### ACCESS ###
-        - id: user-service
+        - id: user-service-access
           uri: lb://USER-SERVICE
           predicates:
             - Path=/user-service/v1/api/access/**
@@ -20,7 +20,7 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*), /$\{segment}
         ### <USER-SERVICE> : AUTHORIZATION (MANAGER)###
-        - id: user-service
+        - id: user-service-manager
           uri: lb://USER-SERVICE
           predicates:
             - Path=/user-service/v1/api/users/**, /user-service/v1/api/managers/**, /user-service/v1/api/shelters/**
@@ -31,11 +31,20 @@ spring:
             - ManagerAuthorizationHeaderFilter
 
         ### <ACTUATOR> ###
-        - id: user-service
+        - id: user-service-actuator
           uri: lb://USER-SERVICE
           predicates:
             - Path=/user-service/actuator/**
             - Method=GET,POST
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+        ### <SWAGGER> ###
+        - id: user-service-swagger
+          uri: lb://USER-SERVICE
+          predicates:
+            - Path=/user-service/v3/api-docs/**
+            - Method=GET,POST,PUT,DELETE
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*), /$\{segment}
@@ -45,3 +54,13 @@ management:
     web:
       exposure:
         include: "*"
+
+springdoc:
+  swagger-ui:
+    urls[0]:
+      name: 회원 서비스
+      url: http://${server.address:localhost}:${server.port}/user-service/v3/api-docs
+    tags-sorter: alpha
+    operations-sorter: method
+
+


### PR DESCRIPTION
## #️⃣ 요약 설명
>gateway에서 다른 마이크로 서비스의 api를 스웨거에 등록할 수 있도록 설정
## 📝 작업 내용

- https://github.com/green-touch/CARING-Back-Gateway/issues

### 문제점
그동안 사용했던 것과 다른 스웨거 라이브러리를 사용.
참고 자료에서는 해당 라이브러리를 다른 마이크로서비스에서도 "똑같이" 사용하라했지만, 404에러가 발생.
따라서 다른 마이크로서비스에서는 이전에 사용했던 스웨거 라이브러리를 사용했더니 제대로 api들을 찾아옴

라우팅쪽에서도 문제가 발생.
마이크로서비스에는 각 prefix가 존재하는데, 라우팅을 위함임. 허나 실제 사용은 해당 prefix를 제외한 주소를 사용해야하는데,
스웨거에서 미리 제거해버리니 존재하지 않는 주소를 사용하게됨

따라서 마이크로서비스의 url 설정에 prefix를 주입해줘야함.

## 동작 확인
<img width="1666" alt="issue#9_1" src="https://github.com/user-attachments/assets/c04b98dd-5f93-42d4-9502-91e13db3915e" />
